### PR TITLE
Fix typos

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -13,7 +13,7 @@ The simplest way to compile Xdx is:
      requires Gtk+ 2.24.0 or later.
 
   3. Type `make install' to install the programs and any data files and
-     documentation (root/adminstrator privileges may be needed to install
+     documentation (root/administrator privileges may be needed to install
      to the default path).
 
   4. When you want to stip the binary when installing, just type:

--- a/MANUAL
+++ b/MANUAL
@@ -72,7 +72,7 @@ Callsign and autologin
 ======================
 The callsign in the first page of the preferences dialog is used for
 recognizing the DX-cluster prompt (so xdx can colorize it) and for autologin.
-When autologin is enabled, a number of commands can be send to the cluster.
+When autologin is enabled, a number of commands can be sent to the cluster.
 You may enter them in the 'Commands' entry, separated by a comma,
 e.g. set/page 0,unset beep' will disable paging and stop beeps.
 You can also use commands when a password is needed. There is a
@@ -90,11 +90,11 @@ Individual messages can be saved to a file when activated from the preferences
 dialog.
 
 $HOME/.xdx/dxspots  DX spots as displayed in the top list.
-$HOME/.xdx/wwv      WCY/WWV anouncements with propagation info.
+$HOME/.xdx/wwv      WCY/WWV announcements with propagation info.
 $HOME/.xdx/toall    Chat messages as displayed in the bottom text widget.
 $HOME/.xdx/wx       Weather information.
 
-When wwv data is saved, files with "tab seperated values" will be saved for
+When wwv data is saved, files with "tab separated values" will be saved for
 every WWV host. This is useful for creating graphs. The format of this file:
 
 YYYMMDDHH	SFI	A	K	R
@@ -195,7 +195,7 @@ the preferences directory will not be loaded unless the path does not end in
 "cty.dat" or cty.dat is not a regular file, i.e. is a directory. In such cases
 the preferences directory will be checked.  The system installed version of
 cty.dat will be loaded as a fallback should the simple tests fail and the
-prefences directory does not contain cty.dat.  There is currently no test of
+preferences directory does not contain cty.dat.  There is currently no test of
 whether the given cty.dat conforms to the specification.
 
 If, for whatever reason, country determination is not desired, creating a 0 byte

--- a/README.developer
+++ b/README.developer
@@ -95,7 +95,7 @@ the eye a break and the brain a cue that a new logical block has begun.
 A function definition has its name begin in column 0 with its return type on
 the line prior.
 
-Mutliple function arguments may be more easily read by lining up the type and
+Multiple function arguments may be more easily read by lining up the type and
 the argument's name in vertical columns as:
 
 static void

--- a/src/save.c
+++ b/src/save.c
@@ -110,7 +110,7 @@ savewwv(gchar *wwv)
         fclose(fp);
     }
 
-    /* extract wwv hostname and save to seperate file for every host */
+    /* extract wwv hostname and save to separate file for every host */
     tmp = g_strdup(wwv + 7);
     ind = index(tmp, ' ');
     *ind = '\0';

--- a/xdx.1.in
+++ b/xdx.1.in
@@ -50,7 +50,7 @@ Although a country file is installed as a part of @PACKAGE_NAME@,
 it will quickly become out of date as updates are made available
 frequently.
 .
-Announcments of udpated country files are sent to the @PACKAGE_NAME@
+Announcements of updated country files are sent to the @PACKAGE_NAME@
 mailing list.
 .
 See the


### PR DESCRIPTION
Hello,

these commits correct are some typing errors in the MANUAL which is displayed to the user and in other texts.

73 de IU5HKX