### PR TITLE
Fix build with -fno-common or GCC-10

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -76,6 +76,7 @@ extern preferencestype preferences;
 static void on_highcheck_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_soundcheck_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 
+guitype *gui;
 
 /**********************************MAIN WINDOW********************************/
 guitype *

--- a/src/gui.h
+++ b/src/gui.h
@@ -53,7 +53,7 @@ typedef struct guitype {
     gchar           *high8tagname;
 } guitype;
 
-guitype *gui;
+extern guitype *gui;
 
 guitype *new_gui(void);
 void create_mainwindow(void);


### PR DESCRIPTION
Without the patch we get a lot of errors due to `multiple definition of `gui';`

-fno-common will be set as default by GCC-10