### PR TITLE
Only define the gui variable in a single location.

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -53,7 +53,7 @@ typedef struct guitype {
     gchar           *high8tagname;
 } guitype;
 
-guitype *gui;
+extern guitype *gui;
 
 guitype *new_gui(void);
 void create_mainwindow(void);

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,7 @@
 #include "utils.h"
 
 
+guitype *gui;
 extern preferencestype preferences;
 GdkVisual *visual;
 gchar *prompttagname, *calltagname;


### PR DESCRIPTION
This is the correct way to do it, and avoids an error in gcc 10.